### PR TITLE
Additional data failure#114

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ downloader:
     BEANSTALK_FEEDBACKOK_QUEUE: feedbackOkTube
     BEANSTALK_FEEDBACKERROR_QUEUE: feedbackErrorTube
     ZIP_CACHEPATH: /tmp/cache
+    ADDITIONALDATA_FAILED_FILENAME: Download_X_filename_X_mislukt.info
   volumes_from:
     - downloader_cache_dv
   links:

--- a/downloader/src/integration/java/nl/idgis/downloadtool/test/TestDownloadFile.java
+++ b/downloader/src/integration/java/nl/idgis/downloadtool/test/TestDownloadFile.java
@@ -24,8 +24,7 @@ public class TestDownloadFile {
 	@Before
 	public void setUp() throws Exception {
 		AdditionalData additionalData  = new AdditionalData();
-		additionalData.setName("someFile");
-		additionalData.setExtension("someExt");
+		additionalData.setName("someFile.someExt");
 		additionalData.setUrl(URL);
 		downloadSource = new DownloadFile(additionalData);
 	}

--- a/downloader/src/integration/java/nl/idgis/downloadtool/test/TestProcessor.java
+++ b/downloader/src/integration/java/nl/idgis/downloadtool/test/TestProcessor.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package nl.idgis.downloadtool.test;
 
 import static org.easymock.EasyMock.anyObject;
@@ -68,7 +65,7 @@ public class TestProcessor  extends EasyMockSupport {
 	 */
 	@Test
 	public void testOK() throws Exception {
-		DownloadRequest downloadRequest = new DownloadRequest("3.14159");
+		DownloadRequest downloadRequest = new DownloadRequest("testrequest3");
 		Download download = new Download();
 		download.setName("download");
 		WfsFeatureType ft = new WfsFeatureType();
@@ -80,8 +77,7 @@ public class TestProcessor  extends EasyMockSupport {
 		ft.setWfsMimetype("KML");
 		download.setFt(ft);
 		AdditionalData additionalData = new AdditionalData();
-		additionalData.setName("someData");
-		additionalData.setExtension("txt");
+		additionalData.setName("someData.txt");
 		additionalData.setUrl("http://httpbin.org/get");
 		List<AdditionalData> additionalDataList = new ArrayList<AdditionalData>();
 		additionalDataList.add(additionalData);
@@ -118,7 +114,7 @@ public class TestProcessor  extends EasyMockSupport {
 	}
 
 	private DownloadRequest makeRequestStrooizout(String mimetype, String extension) {
-		DownloadRequest downloadRequest = new DownloadRequest("3.14159");
+		DownloadRequest downloadRequest = new DownloadRequest("testrequest2");
 		Download download = new Download();
 		download.setName("strooiroutes" + mimetype);
 		WfsFeatureType ft = new WfsFeatureType();
@@ -130,13 +126,11 @@ public class TestProcessor  extends EasyMockSupport {
 		ft.setWfsMimetype(mimetype);
 		download.setFt(ft);
 		AdditionalData additionalDataLayer = new AdditionalData();
-		additionalDataLayer.setName("strooiroutes");
-		additionalDataLayer.setExtension("lyr");
+		additionalDataLayer.setName("strooiroutes.lyr");
 		additionalDataLayer
 				.setUrl("http://gisopenbaar.overijssel.nl/GeoPortal/MIS4GIS/lyr/strooiroutes%20provincie_arc.lyr");
 		AdditionalData additionalDataMetadata = new AdditionalData();
-		additionalDataMetadata.setName("metadata");
-		additionalDataMetadata.setExtension("xml");
+		additionalDataMetadata.setName("metadata.xml");
 		additionalDataMetadata.setUrl(
 				"http://acc-metadata.geodataoverijssel.nl/metadata/dataset/cd349c2f-b2fe-4ed6-b2b9-a00639ebcebb.xml");
 		List<AdditionalData> additionalDataList = new ArrayList<AdditionalData>();
@@ -186,7 +180,7 @@ public class TestProcessor  extends EasyMockSupport {
 	 * @return
 	 */
 	private DownloadRequest makeRequestRayongrenzen(String mimetype, String extension) {
-		DownloadRequest downloadRequest = new DownloadRequest("3.14159");
+		DownloadRequest downloadRequest = new DownloadRequest("testrequest1");
 		Download download = new Download();
 		download.setName("Rayongrenzen" + "_" + extension);
 		WfsFeatureType ft = new WfsFeatureType();
@@ -198,13 +192,11 @@ public class TestProcessor  extends EasyMockSupport {
 		ft.setWfsMimetype(mimetype);
 		download.setFt(ft);
 		AdditionalData additionalDataLayer = new AdditionalData();
-		additionalDataLayer.setName("Rayongrenzen");
-		additionalDataLayer.setExtension("lyr");
+		additionalDataLayer.setName("Rayongrenzen.lyr");
 		additionalDataLayer
 				.setUrl("http://gisopenbaar.overijssel.nl/GeoPortal/MIS4GIS/lyr/rayonwk_polygon.lyr");
 		AdditionalData additionalDataMetadata = new AdditionalData();
-		additionalDataMetadata.setName("metadata");
-		additionalDataMetadata.setExtension("xml");
+		additionalDataMetadata.setName("metadata.xml");
 		additionalDataMetadata.setUrl(
 				"http://test-metadata.geodataoverijssel.nl/metadata/dataset/7e03c460-f8b1-4ada-97e7-1ad2dfe98be8.xml");
 		List<AdditionalData> additionalDataList = new ArrayList<AdditionalData>();
@@ -250,4 +242,56 @@ public class TestProcessor  extends EasyMockSupport {
 		verify(feedbackQueueMock);
 	}	
 	
+	/**
+	 * Fill wfsMimetype with null to test correct behaviour in processor.
+	 * @param extension
+	 * @return
+	 */
+	private DownloadRequest makeRequestOppWater(String mimetype, String extension) {
+		DownloadRequest downloadRequest = new DownloadRequest("testrequestB3OppWater");
+		Download download = new Download();
+		download.setName("B3OppWater" + "_" + extension);
+		WfsFeatureType ft = new WfsFeatureType();
+		ft.setCrs("EPSG:28992");
+		ft.setName("B3_Oppervlaktewateren");
+		ft.setExtension(extension);
+		ft.setServiceUrl("http://test-services.geodataoverijssel.nl/geoserver/B35_waterlopen/wfs");
+		ft.setServiceVersion("2.0.0");
+		ft.setWfsMimetype(mimetype);
+		download.setFt(ft);
+		AdditionalData additionalDataLayer = new AdditionalData();
+		additionalDataLayer.setName("B3_Oppervlaktewateren.lyr");
+		additionalDataLayer
+				.setUrl("http://gisopenbaar.overijssel.nl/GeoPortal/MIS4GIS/lyr/WRONG_polygon.lyr");
+		AdditionalData additionalDataMetadata = new AdditionalData();
+		additionalDataMetadata.setName("metadata.xml");
+		additionalDataMetadata.setUrl(
+				"http://test-metadata.geodataoverijssel.nl/metadata/dataset/12345.xml");
+		List<AdditionalData> additionalDataList = new ArrayList<AdditionalData>();
+		additionalDataList.add(additionalDataLayer);
+		additionalDataList.add(additionalDataMetadata);
+		download.setAdditionalData(additionalDataList);
+		downloadRequest.setDownload(download);
+		return downloadRequest;
+	}
+
+
+	@Test
+	public void testOppWaterGML3() throws Exception {
+		DownloadRequest downloadRequest = makeRequestOppWater("gml32", "gml");
+		downloadRequest.setConvertToMimetype("gml32");
+		expect(queueClientMock.receiveDownloadRequest()).andReturn(downloadRequest);
+		queueClientMock.deleteDownloadRequest(downloadRequest);
+		replay(queueClientMock);
+		
+		feedbackQueueMock.sendFeedback(anyObject(Feedback.class));
+		replay(feedbackQueueMock);
+		
+		downloadProcessor.processDownloadRequest();
+		
+		verify(queueClientMock);
+		verify(feedbackQueueMock);
+	}
+
+
 }

--- a/downloader/src/main/java/nl/idgis/downloadtool/downloader/DownloadFile.java
+++ b/downloader/src/main/java/nl/idgis/downloadtool/downloader/DownloadFile.java
@@ -73,7 +73,7 @@ public class DownloadFile implements DownloadSource {
 		
 		int statusCode = statusLine.getStatusCode();
 		if(statusCode != 200) {
-			throw new IOException("Unexpected http status code: " + statusCode);
+			throw new IOException(statusLine.toString() + " : " + uri.toString());
 		}
 		
 		entity = response.getEntity();

--- a/downloader/src/main/java/nl/idgis/downloadtool/downloader/DownloadProcessor.java
+++ b/downloader/src/main/java/nl/idgis/downloadtool/downloader/DownloadProcessor.java
@@ -44,7 +44,7 @@ public class DownloadProcessor {
 
 	private static final int BUF_SIZE = 4096;
 
-	private static final String FILENAME_PLACEHOLDER = "##filename##";
+	private static final String FILENAME_PLACEHOLDER = "X_filename_X";
 
 	private DownloadQueue queueClient;
 	private FeedbackQueue feedbackQueue, errorFeedbackQueue;
@@ -72,9 +72,9 @@ public class DownloadProcessor {
 
 	/**
 	 * If an additional download fails, then use this string as the filename in the zip.<br>
-	 * @param additionalDataFailedFilename filename of the form "prefix##filename##postfix". <br>
-	 * ##filename## will be replaced by the original filename.<br>
-	 * e.g. "Download_##filename##_mislukt" wordt "Download_MetaData_mislukt"
+	 * @param additionalDataFailedFilename filename of the form "prefixX_filename_Xpostfix". <br>
+	 * X_filename_X will be replaced by the original filename.<br>
+	 * e.g. "Download_X_filename_X_mislukt" wordt "Download_MetaData_mislukt"
 	 */
 	private void setAddDataFailedFilename(String additionalDataFailedFilename) {
 		this.additionalDataFailedFilename = additionalDataFailedFilename;

--- a/downloader/src/main/java/nl/idgis/downloadtool/downloader/DownloadWfs.java
+++ b/downloader/src/main/java/nl/idgis/downloadtool/downloader/DownloadWfs.java
@@ -95,7 +95,7 @@ public class DownloadWfs implements DownloadSource {
 		
 		int statusCode = statusLine.getStatusCode();
 		if(statusCode != 200) {
-			throw new IOException("Unexpected http status code: " + statusCode);
+			throw new IOException(statusLine.toString() + " : " + uri.toString());
 		}
 		
 		entity = response.getEntity();


### PR DESCRIPTION
when there is an error during download of featuretype or additional data, a file entry in the zip will contain the error message. File entry name works with a placeholder (X_filename_X) and is customizable (env. var. ADDITIONALDATA_FAILED_FILENAME: Download_X_filename_X_mislukt.info)