### PR TITLE
Update postgres driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ configure([
 project(':dao') {
 	dependencies {
 		compile project(':domain')
-		compile 'org.postgresql:postgresql:9.4.1208.jre7'
+		compile 'org.postgresql:postgresql:42.7.7'
 		compile 'com.google.code.gson:gson:2.5'
 	}
 }


### PR DESCRIPTION
In voorbereiding op de postgres 17 upgrade moet deze driver upgrade ook plaatsvinden. Dit vanwege veranderde wachtwoord hashing. Het is backwards compatible dus een versie met deze aanpassing er in gaat ook werken op postgres 9.5.